### PR TITLE
feat: integrar React 18 en HTML y renderizar avatares con createElement

### DIFF
--- a/react/1_basic/index.html
+++ b/react/1_basic/index.html
@@ -21,12 +21,38 @@
         filter: grayscale(100%);
       }
     </style>
+      <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>  
+      <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   </head>
   <body>
     <h1>Welcome to woman</h1>
     <div id="app"></div>
     <script>
+      // Este es un componente React simple que renderiza un avatar con una imagen y un nombre.
+      // Utiliza el método React.createElement para crear el componente y renderizarlo en la app.
       const app = document.getElementById('app');
+      const h = React.createElement;
+      const Avatar = params => {
+        const src = `https://randomuser.me/api/portraits/women/${params.id}.jpg`;
+        return h("img", {src});
+      };
+      ReactDOM.render(
+        h(
+          "div",
+          null,
+          h(Avatar, {id: 5}),
+          h(Avatar, {id: 2}),
+          h(Avatar, {id: 3}),
+          h(Avatar, {id: 4}),
+          h(Avatar, {id: 1}),
+          h(Avatar, {id: 6}),
+          h(Avatar, {id: 7}),
+          h(Avatar, {id: 8})
+        ),
+        app
+      );
+
+      /*
       const Avatar = params => {
         const src = `https://randomuser.me/api/portraits/women/${params.id}.jpg`;
         return `<picture>
@@ -47,7 +73,7 @@
         img.addEventListener('click', () => {
           img.classList.toggle('disabled');
         });
-      });
+      });*/
     </script>
   </body>
 </html>


### PR DESCRIPTION
Se integran los scripts UMD de React y ReactDOM (versión 18) directamente en el HTML, habilitando el uso de React sin herramientas de compilación (como Babel o Webpack).

✔ Se crea un componente `Avatar` que genera imágenes a partir de un ID dinámico ✔ Se utiliza React.createElement en lugar de JSX para crear los elementos de manera manual ✔ Se renderiza una galería de avatares dentro de un <div> contenedor usando ReactDOM.render ✔ Punto de montaje en #app definido previamente en el HTML